### PR TITLE
ひとまずのシュミレーションしてみた

### DIFF
--- a/srcs/philo.h
+++ b/srcs/philo.h
@@ -18,6 +18,12 @@
 # define THINK "thinking"
 # define DIE "died"
 
+//color settings
+# define RED "\033[31m"
+# define GREEN "\033[32m"
+# define YELLOW "\033[33m"
+# define RESET "\033[0m"
+
 typedef struct s_thread_data
 {
 	int				order;


### PR DESCRIPTION
put_status()関数でそれぞれのスレッドの生存確認と出力。  
### いずれかのスレッドが死んだ時
- put_status()内のmutexロック内で確認
- 死亡確認したら死亡情報出力
- 他の出力待ちスレッドはその死亡を確認してから処理をするので出力が前後することはない